### PR TITLE
Support multiple audiences and issuers in token validation

### DIFF
--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator/Authentication/AuthenticationServiceCollectionExtensions.cs
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator/Authentication/AuthenticationServiceCollectionExtensions.cs
@@ -5,6 +5,8 @@
 namespace Microsoft.Teams.Apps.CompanyCommunicator.Authentication
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using Microsoft.AspNetCore.Authentication.AzureAD.UI;
     using Microsoft.AspNetCore.Authentication.JwtBearer;
     using Microsoft.AspNetCore.Authorization;
@@ -17,6 +19,11 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Authentication
     /// </summary>
     public static class AuthenticationServiceCollectionExtensions
     {
+        private static readonly string ClientIdConfigurationSettingKey = "AzureAd:ClientId";
+        private static readonly string TenantIdConfigurationSettingKey = "AzureAd:TenantId";
+        private static readonly string ValidAudiencesConfigurationSettingKey = "AzureAd:ValidAudiences";
+        private static readonly string ValidIssuersConfigurationSettingKey = "AzureAd:ValidIssuers";
+
         /// <summary>
         /// Extension method to register the authentication services.
         /// </summary>
@@ -30,8 +37,12 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Authentication
         }
 
         // This method works specifically for single tenant application.
-        private static void RegisterAuthenticationServices(IServiceCollection services, IConfiguration configuration)
+        private static void RegisterAuthenticationServices(
+            IServiceCollection services,
+            IConfiguration configuration)
         {
+            AuthenticationServiceCollectionExtensions.ValidateAuthenticationConfigurationSettings(configuration);
+
             services.AddAuthentication(options => { options.DefaultScheme = JwtBearerDefaults.AuthenticationScheme; })
                 .AddJwtBearer(options =>
                 {
@@ -40,11 +51,82 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Authentication
                     options.Authority = $"{azureADOptions.Instance}{azureADOptions.TenantId}/v2.0";
                     options.TokenValidationParameters = new TokenValidationParameters
                     {
-                        ValidAudience = $"{azureADOptions.ClientId}",
-                        ValidIssuer = $"{azureADOptions.Instance}{azureADOptions.TenantId}/v2.0",
+                        ValidAudiences = AuthenticationServiceCollectionExtensions.GetValidAudiences(configuration),
+                        ValidIssuers = AuthenticationServiceCollectionExtensions.GetValidIssuers(configuration),
                         IssuerValidator = AuthenticationServiceCollectionExtensions.IssuerValidator,
                     };
                 });
+        }
+
+        private static void ValidateAuthenticationConfigurationSettings(IConfiguration configuration)
+        {
+            var clientId = configuration[AuthenticationServiceCollectionExtensions.ClientIdConfigurationSettingKey];
+            if (string.IsNullOrWhiteSpace(clientId))
+            {
+                throw new ApplicationException("Azure AD ClientId is missing in configuration file.");
+            }
+
+            var tenantId = configuration[AuthenticationServiceCollectionExtensions.TenantIdConfigurationSettingKey];
+            if (string.IsNullOrWhiteSpace(tenantId))
+            {
+                throw new ApplicationException("Azure AD TenantId is missing in configuration file.");
+            }
+
+            var validAudiences = configuration[AuthenticationServiceCollectionExtensions.ValidAudiencesConfigurationSettingKey];
+            if (string.IsNullOrWhiteSpace(validAudiences))
+            {
+                throw new ApplicationException("Azure AD ValidAudiences is missing in configuration file.");
+            }
+
+            var validIssuers = configuration[AuthenticationServiceCollectionExtensions.ValidIssuersConfigurationSettingKey];
+            if (string.IsNullOrWhiteSpace(validIssuers))
+            {
+                throw new ApplicationException("Azure AD ValidIssuers is missing in configuration file.");
+            }
+        }
+
+        private static IEnumerable<string> GetSettings(IConfiguration configuration, string configurationSettingKey)
+        {
+            var configurationSettingValue = configuration[configurationSettingKey];
+            var settings = configurationSettingValue
+                ?.Split(new char[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries)
+                ?.Select(p => p.Trim());
+            if (settings == null)
+            {
+                throw new ApplicationException($"{configurationSettingKey} doesn't contain valid settings in configuration.");
+            }
+
+            return settings;
+        }
+
+        private static IEnumerable<string> GetValidAudiences(IConfiguration configuration)
+        {
+            var clientId = configuration[AuthenticationServiceCollectionExtensions.ClientIdConfigurationSettingKey];
+
+            var validAudiences = new List<string> { clientId };
+
+            var configurationSettings =
+                AuthenticationServiceCollectionExtensions.GetSettings(
+                    configuration,
+                    AuthenticationServiceCollectionExtensions.ValidAudiencesConfigurationSettingKey);
+
+            validAudiences.AddRange(configurationSettings);
+
+            return validAudiences;
+        }
+
+        private static IEnumerable<string> GetValidIssuers(IConfiguration configuration)
+        {
+            var tenantId = configuration[AuthenticationServiceCollectionExtensions.TenantIdConfigurationSettingKey];
+
+            var validIssuers =
+                AuthenticationServiceCollectionExtensions.GetSettings(
+                    configuration,
+                    AuthenticationServiceCollectionExtensions.ValidIssuersConfigurationSettingKey);
+
+            validIssuers = validIssuers.Select(validIssuer => validIssuer.Replace("TENANT_ID", tenantId));
+
+            return validIssuers;
         }
 
         private static string IssuerValidator(
@@ -52,9 +134,9 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Authentication
             SecurityToken securityToken,
             TokenValidationParameters validationParameters)
         {
-            var validIssuer = validationParameters?.ValidIssuer;
-            if (!string.IsNullOrWhiteSpace(validIssuer)
-                && validIssuer.Equals(issuer, StringComparison.OrdinalIgnoreCase))
+            var validIssuers = validationParameters?.ValidIssuers;
+            if (validIssuers != null &&
+                validIssuers.Any(validIssuer => issuer.Equals(validIssuer, StringComparison.OrdinalIgnoreCase)))
             {
                 return issuer;
             }

--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator/appsettings.json
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator/appsettings.json
@@ -2,7 +2,9 @@
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
     "TenantId": "[AzureAD Tenant Id]",
-    "ClientId": "[AzureAD Client Id]"
+    "ClientId": "[AzureAD Client Id]",
+    "ValidAudiences": "[Audience list]",
+    "ValidIssuers": "https://login.microsoftonline.com/TENANT_ID/v2.0,https://sts.windows.net/TENANT_ID/"
   },
   "Logging": {
     "LogLevel": {

--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator/appsettings.json
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator/appsettings.json
@@ -3,7 +3,7 @@
     "Instance": "https://login.microsoftonline.com/",
     "TenantId": "[AzureAD Tenant Id]",
     "ClientId": "[AzureAD Client Id]",
-    "ValidAudiences": "[Audience list]",
+    "ApplicationIdURI": "[AzureAD Application Id URI]",
     "ValidIssuers": "https://login.microsoftonline.com/TENANT_ID/v2.0,https://sts.windows.net/TENANT_ID/"
   },
   "Logging": {


### PR DESCRIPTION
This PR includes the following change:
* Support multiple audiences and issuers in token validation, and make it configurable.