### PR TITLE
Skip AFD for /api routes

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -569,11 +569,37 @@
                 "/*"
               ],
               "routeConfiguration": {
-                "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",                                
+                "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
                 "forwardingProtocol": "HttpsOnly",
                 "backendPool": {
-                    "id": "[resourceId('Microsoft.Network/frontDoors/backendPools', variables('frontDoorName'), 'backendPool1')]"
-                }                                
+                  "id": "[resourceId('Microsoft.Network/frontDoors/backendPools', variables('frontDoorName'), 'backendPool1')]"
+                }
+              },
+              "enabledState": "Enabled"
+            }
+          },
+          {
+            "name": "routingRule2",
+            "properties": {
+              "frontendEndpoints": [
+                {
+                  "id": "[resourceId('Microsoft.Network/frontDoors/frontendEndpoints', variables('frontDoorName'), 'frontendEndpoint1')]"
+                }
+              ],
+              "acceptedProtocols": [
+                "Https"
+              ],
+              "patternsToMatch": [
+                "/api/*"
+              ],
+              "routeConfiguration": {
+                "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorRedirectConfiguration",
+                "customFragment": null,
+                "customHost": "[variables('botAppDomain')]",
+                "customPath": "",
+                "redirectProtocol": "HttpsOnly",
+                "customQueryString": null,
+                "redirectType": "PermanentRedirect"
               },
               "enabledState": "Enabled"
             }

--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -258,7 +258,13 @@
               "name": "WEBSITE_NODE_DEFAULT_VERSION",
               "value": "10.15.2"
             }
-          ]
+          ],
+          "cors": {
+            "supportCredentials": true,
+            "allowedOrigins": [
+              "[concat('https://', variables('frontDoorDomain'))]"
+            ]
+          }
         }
       },
       "dependsOn": [


### PR DESCRIPTION
The API call to send a message can take a long time, causing 503 errors from AFD.
- Configure AFD routing rules to do a redirect to the main app service for routes under /api
- Set up CORS on the app service to allow cross-origin calls from the AFD domain