### PR TITLE
Update GroupService to fix return when 0 result count is requested

### DIFF
--- a/Source/Microsoft.Teams.Apps.CompanyCommunicator.Common/Services/MicrosoftGraph/Groups/GroupsService.cs
+++ b/Source/Microsoft.Teams.Apps.CompanyCommunicator.Common/Services/MicrosoftGraph/Groups/GroupsService.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGrap
         {
             if (resultCount == 0)
             {
-                return default;
+                return new List<Group>();
             }
 
             string filterforDL = $"mailEnabled eq true and (startsWith(mail,'{query}') or startsWith(displayName,'{query}'))";
@@ -151,7 +151,7 @@ namespace Microsoft.Teams.Apps.CompanyCommunicator.Common.Services.MicrosoftGrap
         {
             if (resultCount == 0)
             {
-                return default;
+                return new List<Group>();
             }
 
             string filterforSG = $"mailEnabled eq false and securityEnabled eq true and startsWith(displayName,'{query}')";


### PR DESCRIPTION
When the [SearchM365GroupsAsync](https://github.com/OfficeDev/microsoft-teams-company-communicator-app/blob/master/Source/Microsoft.Teams.Apps.CompanyCommunicator.Common/Services/MicrosoftGraph/Groups/GroupsService.cs#L81) returns 25 results (the default result count) the next steps call to add the [Distribution Groups](https://github.com/OfficeDev/microsoft-teams-company-communicator-app/blob/master/Source/Microsoft.Teams.Apps.CompanyCommunicator.Common/Services/MicrosoftGraph/Groups/GroupsService.cs#L82) and [Security Groups](https://github.com/OfficeDev/microsoft-teams-company-communicator-app/blob/master/Source/Microsoft.Teams.Apps.CompanyCommunicator.Common/Services/MicrosoftGraph/Groups/GroupsService.cs#L83) gonna be called with an Zero resultCount, and those methods will return a default (aka null). And this will throw an Exception. I just put an working around that returns an empty List<Group>() and it's fixed.