### PR TITLE
Adding storage account creation properties.  Fix one Bug, Clears 2 old PR's

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -156,6 +156,10 @@
       "apiVersion": "2018-02-01",
       "location": "[parameters('location')]",
       "kind": "Storage",
+      "properties": {
+          "supportsHttpsTrafficOnly": true,
+          "allowBlobPublicAccess": false
+        },
       "sku": {
         "name": "Standard_LRS"
       }


### PR DESCRIPTION
# Overview

This PR will add storage account properties  
- `supportsHttpsTrafficOnly` which is in the salled pr #134 
- `allowBlobPublicAccess` This fixes issue #220 and will render PR #211 obsolete. 

# Testing

I tested the deployment twice.  Both tests were successful.   When testing I pushed the bot to a subscription that had a policy restricting the creation of public storage accounts. 

# CLS

I have signed the CLA with my companies approval.

# Closes

Resolves #220  
Closes #134, Closes #211  